### PR TITLE
Deps/pact net v5.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x" # runners already have .Net Framework installed as well
+          dotnet-version: "8.0.x" # runners already have .Net Framework installed as well
 
       # - name: Step 1 - Restore Consumer
       #   run: dotnet restore

--- a/Consumer/src/consumer.csproj
+++ b/Consumer/src/consumer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Consumer/tests/ApiTest.cs
+++ b/Consumer/tests/ApiTest.cs
@@ -5,8 +5,6 @@ using Xunit;
 using System.Net.Http;
 using System.Net;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Consumer;
 using PactNet.Matchers;
 using System.Threading.Tasks;
@@ -32,10 +30,6 @@ namespace tests
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
                 Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                },
                 LogLevel = PactLogLevel.Debug // STEP_8
             };
 

--- a/Consumer/tests/tests.csproj
+++ b/Consumer/tests/tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="PactNet" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="PactNet" Version="5.0.0" />
     <PackageReference Include="PactNet.Output.Xunit" Version="1.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Provider/src/provider.csproj
+++ b/Provider/src/provider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Development' " />
@@ -9,10 +9,6 @@
     <Folder Include="wwwroot\" />
     <Folder Include="Repositories\" />
     <Folder Include="Model\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Provider/tests/Middleware/ProviderStateMiddleware.cs
+++ b/Provider/tests/Middleware/ProviderStateMiddleware.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 using provider.Model;
 using provider.Repositories;
 
@@ -91,7 +91,7 @@ namespace tests.Middleware
                     jsonRequestBody = await reader.ReadToEndAsync();
                 }
 
-                var providerState = JsonConvert.DeserializeObject<ProviderState>(jsonRequestBody);
+                var providerState = JsonSerializer.Deserialize<ProviderState>(jsonRequestBody);
 
                 //A null or empty provider state key must be handled
                 if (providerState != null && !String.IsNullOrEmpty(providerState.State))

--- a/Provider/tests/ProductTest.cs
+++ b/Provider/tests/ProductTest.cs
@@ -38,9 +38,9 @@ namespace tests
                 _webHost.Start();
 
                 //Act / Assert
-                IPactVerifier pactVerifier = new PactVerifier(config);
+                IPactVerifier pactVerifier = new PactVerifier("ProductService", config);
                 var pactFile = new FileInfo(Path.Join("..", "..", "..", "..", "..", "pacts", "ApiClient-ProductService.json"));
-                pactVerifier.ServiceProvider("ProductService", new Uri(_pactServiceUri))
+                pactVerifier.WithHttpEndpoint(new Uri(_pactServiceUri))
                 .WithFileSource(pactFile)
                 .WithProviderStateUrl(new Uri($"{_pactServiceUri}/provider-states"))
                 .Verify();

--- a/Provider/tests/tests.csproj
+++ b/Provider/tests/tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="PactNet" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="PactNet" Version="5.0.0" />
     <PackageReference Include="PactNet.Output.Xunit" Version="1.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/readme.md
+++ b/readme.md
@@ -238,8 +238,7 @@ using Xunit;
 using System.Net.Http;
 using System.Net;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+
 using Consumer;
 using PactNet.Matchers;
 using System.Threading.Tasks;
@@ -388,9 +387,9 @@ namespace tests
                 _webHost.Start();
 
                 //Act / Assert
-                IPactVerifier pactVerifier = new PactVerifier(config);
+                IPactVerifier pactVerifier = new PactVerifier("ProductService", config);
                 var pactFile = new FileInfo(Path.Join("..", "..", "..", "..", "..", "pacts", "ApiClient-ProductService.json"));
-                pactVerifier.ServiceProvider("ProductService", new Uri(_pactServiceUri))
+                pactVerifier.WithHttpEndpoint(new Uri(_pactServiceUri))
                 .WithFileSource(pactFile)
                 .WithProviderStateUrl(new Uri($"{_pactServiceUri}/provider-states"))
                 .Verify();

--- a/readme.md
+++ b/readme.md
@@ -263,11 +263,7 @@ namespace tests
             var Config = new PactConfig
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
-                Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                }
+                Outputters = new[] { new XUnitOutput(output) }
             };
 
             pact = Pact.V3("ApiClient", "ProductService", Config).WithHttpInteractions(port);
@@ -1123,10 +1119,6 @@ The standard logs, don't always give us enough information in case of failure, y
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
                 Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                },
                 LogLevel = PactLogLevel.Debug // STEP_8
             };
 ```

--- a/step10/Provider/tests/Middleware/ProviderStateMiddleware.cs
+++ b/step10/Provider/tests/Middleware/ProviderStateMiddleware.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 using provider.Model;
 using provider.Repositories;
 
@@ -92,7 +92,7 @@ namespace tests.Middleware
                     jsonRequestBody = await reader.ReadToEndAsync();
                 }
 
-                var providerState = JsonConvert.DeserializeObject<ProviderState>(jsonRequestBody);
+                var providerState = JsonSerializer.Deserialize<ProviderState>(jsonRequestBody);
 
                 //A null or empty provider state key must be handled
                 if (providerState != null && !String.IsNullOrEmpty(providerState.State))

--- a/step5/Consumer/tests/ApiTest.cs
+++ b/step5/Consumer/tests/ApiTest.cs
@@ -30,10 +30,6 @@ namespace tests
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
                 Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                },
                 LogLevel = PactLogLevel.Debug // STEP_8
             };
 

--- a/step5/Consumer/tests/ApiTest.cs
+++ b/step5/Consumer/tests/ApiTest.cs
@@ -5,8 +5,6 @@ using Xunit;
 using System.Net.Http;
 using System.Net;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Consumer;
 using PactNet.Matchers;
 using System.Threading.Tasks;

--- a/step6/Consumer/tests/ApiTest.cs
+++ b/step6/Consumer/tests/ApiTest.cs
@@ -30,10 +30,6 @@ namespace tests
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
                 Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                },
                 LogLevel = PactLogLevel.Debug // STEP_8
             };
 

--- a/step6/Consumer/tests/ApiTest.cs
+++ b/step6/Consumer/tests/ApiTest.cs
@@ -5,8 +5,6 @@ using Xunit;
 using System.Net.Http;
 using System.Net;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Consumer;
 using PactNet.Matchers;
 using System.Threading.Tasks;

--- a/step7/Provider/tests/Middleware/ProviderStateMiddleware.cs
+++ b/step7/Provider/tests/Middleware/ProviderStateMiddleware.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 using provider.Model;
 using provider.Repositories;
 
@@ -91,7 +91,7 @@ namespace tests.Middleware
                     jsonRequestBody = await reader.ReadToEndAsync();
                 }
 
-                var providerState = JsonConvert.DeserializeObject<ProviderState>(jsonRequestBody);
+                var providerState = JsonSerializer.Deserialize<ProviderState>(jsonRequestBody);
 
                 //A null or empty provider state key must be handled
                 if (providerState != null && !String.IsNullOrEmpty(providerState.State))

--- a/step8/Consumer/tests/ApiTest.cs
+++ b/step8/Consumer/tests/ApiTest.cs
@@ -30,10 +30,6 @@ namespace tests
             {
                 PactDir = Path.Join("..", "..", "..", "..", "..", "pacts"),
                 Outputters = new[] { new XUnitOutput(output) },
-                DefaultJsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                },
                 LogLevel = PactLogLevel.Debug // STEP_8
             };
 

--- a/step8/Consumer/tests/ApiTest.cs
+++ b/step8/Consumer/tests/ApiTest.cs
@@ -5,8 +5,6 @@ using Xunit;
 using System.Net.Http;
 using System.Net;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Consumer;
 using PactNet.Matchers;
 using System.Threading.Tasks;


### PR DESCRIPTION
Updates repository to utilise pact-net v5.x - https://github.com/pact-foundation/pact-net/releases/tag/5.0.0

Previous [Pact-Net 4.5.x](https://github.com/pact-foundation/pact-net/tree/release/4.x) compliant workshop is archived in branch [`master-v4.5.0`](https://github.com/pact-foundation/pact-workshop-dotnet/tree/master-v4.5.0)